### PR TITLE
change link from books to email in email blog card

### DIFF
--- a/blog.html
+++ b/blog.html
@@ -91,7 +91,7 @@
                 <img class="card-img-top" src="images/email.png" alt="Email icon">
                 <div class="card-body">
                   <p class="my-card-text"><span class="bold"><a
-                        href="blog_posts/books.html"
+                        href="blog_posts/email.html"
                         target="_blank">How to E-mail Your Professor</a></span></br>September 4, 2021</p>
                 </div>
               </div>


### PR DESCRIPTION
Super quick change to fix a typo in the email blog card.

Currently, it links to the books post. The quick change just links to the email post instead.